### PR TITLE
feat: add SPARQL history logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,9 @@ TZ=Asia/Tokyo
 # the path to /var/log/togomcp/<file>.jsonl to surface logs as ./logs[-test]/.
 # TOGOMCP_QUERY_LOG=/var/log/togomcp/togomcp.jsonl
 # TOGOMCP_QUERY_LOG_TEST=/var/log/togomcp/togomcp-test.jsonl
+
+# Optional: enable SPARQL-only history logging for reproducibility.
+# This stores exact query text and compact execution metadata/result hash,
+# not full result bodies.
+# TOGOMCP_SPARQL_HISTORY=/var/log/togomcp/sparql-history.jsonl
+# TOGOMCP_SPARQL_HISTORY_TEST=/var/log/togomcp/sparql-history-test.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ scripts/mie_keyword_suggestions.yaml
 logs/
 logs-test/
 *.jsonl
+# Local git worktrees
+.worktrees/
+worktrees/

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ mainly need to reproduce or debug SPARQL runs.
 ### Docker
 
 `compose.yaml` bind-mounts `./logs` (and `./logs-test`) on the host to
-`/var/log/togomcp` inside each container and passes through `TOGOMCP_QUERY_LOG`
-/ `TOGOMCP_QUERY_LOG_TEST` from `.env`. Opt in:
+`/var/log/togomcp` inside each container and passes through the query-log and
+SPARQL-history logging env vars from `.env`. Opt in:
 
 ```bash
 echo 'TOGOMCP_QUERY_LOG=/var/log/togomcp/togomcp.jsonl' >> .env
@@ -161,9 +161,10 @@ docker compose up -d togomcp-main
 tail -f logs/sparql-history.jsonl
 ```
 
-The path in the env var is the **container-side** path; the bind mount makes
-the same file visible at `./logs/togomcp.jsonl` on your host. Leaving the var
-unset keeps logging off — no compose changes needed.
+The path in each env var is the **container-side** path. Container paths under
+`/var/log/togomcp/<file>.jsonl` appear as `./logs/<file>.jsonl` for
+`togomcp-main` and `./logs-test/<file>.jsonl` for `togomcp-test`. Leaving the
+vars unset keeps logging off — no compose changes needed.
 
 ### Claude Desktop (local stdio)
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ and reconstructing multi-tool sequences.
 (zero-overhead default). Set to a writable file path to enable.
 Output uses `RotatingFileHandler` (50 MB × 10, ~500 MB cap).
 
+### SPARQL History Logging (Optional)
+
+For reproducibility, TogoMCP can also record a SPARQL-only execution history.
+Set `TOGOMCP_SPARQL_HISTORY` to a writable JSONL path. Each `run_sparql` call
+appends the exact SPARQL text, original database/endpoint arguments, resolved
+endpoint URL, status, HTTP code, elapsed time, row/byte counts, query SHA-256,
+and result SHA-256. Full result bodies are not stored; only the exact query
+text and compact execution metadata/result hash are recorded.
+
+This is separate from `TOGOMCP_QUERY_LOG`: use `TOGOMCP_QUERY_LOG` for complete
+MCP tool-call auditing across all tools, and `TOGOMCP_SPARQL_HISTORY` when you
+mainly need to reproduce or debug SPARQL runs.
+
 ### Docker
 
 `compose.yaml` bind-mounts `./logs` (and `./logs-test`) on the host to
@@ -137,6 +150,15 @@ echo 'TOGOMCP_QUERY_LOG=/var/log/togomcp/togomcp.jsonl' >> .env
 mkdir -p logs
 docker compose up -d togomcp-main
 tail -f logs/togomcp.jsonl
+```
+
+To enable SPARQL history in Docker as well:
+
+```bash
+echo 'TOGOMCP_SPARQL_HISTORY=/var/log/togomcp/sparql-history.jsonl' >> .env
+mkdir -p logs
+docker compose up -d togomcp-main
+tail -f logs/sparql-history.jsonl
 ```
 
 The path in the env var is the **container-side** path; the bind mount makes
@@ -152,7 +174,8 @@ parent directory exists:
 ```json
 "env": {
     "NCBI_API_KEY": "your-key-here",
-    "TOGOMCP_QUERY_LOG": "/Users/you/togomcp-logs/togomcp.jsonl"
+    "TOGOMCP_QUERY_LOG": "/Users/you/togomcp-logs/togomcp.jsonl",
+    "TOGOMCP_SPARQL_HISTORY": "/Users/you/togomcp-logs/sparql-history.jsonl"
 }
 ```
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,6 +8,7 @@ services:
       NCBI_API_KEY: ${NCBI_API_KEY}
       TZ: ${TZ:-Asia/Tokyo}
       TOGOMCP_QUERY_LOG: ${TOGOMCP_QUERY_LOG:-}
+      TOGOMCP_SPARQL_HISTORY: ${TOGOMCP_SPARQL_HISTORY:-}
     volumes:
       - ./logs:/var/log/togomcp
     restart: unless-stopped
@@ -21,6 +22,7 @@ services:
       NCBI_API_KEY: ${NCBI_API_KEY}
       TZ: ${TZ:-Asia/Tokyo}
       TOGOMCP_QUERY_LOG: ${TOGOMCP_QUERY_LOG_TEST:-}
+      TOGOMCP_SPARQL_HISTORY: ${TOGOMCP_SPARQL_HISTORY_TEST:-}
     volumes:
       - ./logs-test:/var/log/togomcp
     restart: unless-stopped

--- a/docs/superpowers/plans/2026-05-19-sparql-history.md
+++ b/docs/superpowers/plans/2026-05-19-sparql-history.md
@@ -1,0 +1,542 @@
+# SPARQL History Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in SPARQL-specific JSONL history logging so users can reproduce `run_sparql` executions with exact query text, resolved endpoint, outcome, and compact result metadata.
+
+**Architecture:** Implement a failure-safe `_SparqlHistoryLogger` in `togo_mcp/server.py` and call it from `execute_sparql()` in a `finally` block. Keep the existing `TOGOMCP_QUERY_LOG` middleware unchanged and add documentation/config examples for the new `TOGOMCP_SPARQL_HISTORY` environment variable.
+
+**Tech Stack:** Python 3.11+, FastMCP, httpx, stdlib `logging.handlers.RotatingFileHandler`, pytest, uv.
+
+---
+
+## File structure
+
+- Modify `togo_mcp/server.py`
+  - Add `_SparqlHistoryLogger` and `_sparql_history_logger` near the existing logging helpers.
+  - Update `execute_sparql()` to build a reproducibility record and write it on success or failure.
+- Modify `tests/test_server.py`
+  - Add tests for disabled history logging, successful records, HTTP-error records, timeout records, and write-failure safety.
+- Modify `README.md`
+  - Document SPARQL history logging near the existing Tool-Call Logging section.
+- Modify `.env.example`
+  - Add optional Docker env examples for main and test SPARQL history files.
+- Modify `compose.yaml`
+  - Pass through `TOGOMCP_SPARQL_HISTORY` and `TOGOMCP_SPARQL_HISTORY_TEST` to the containers.
+
+## Task 1: Add failing tests for SPARQL history logging
+
+**Files:**
+- Modify: `tests/test_server.py`
+
+- [ ] **Step 1: Add helper classes and fixtures for fake SPARQL responses**
+
+Append these helpers after `_make_logger()` in `tests/test_server.py`:
+
+```python
+class _FakeResponse:
+    def __init__(self, text: str, status_code: int, url: str = "https://fake.example/sparql") -> None:
+        self.text = text
+        self.status_code = status_code
+        self.url = url
+        self.content = text.encode("utf-8")
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status_code < 300
+
+
+class _FakeSparqlClient:
+    def __init__(self, response: _FakeResponse | None = None, exc: Exception | None = None) -> None:
+        self.response = response
+        self.exc = exc
+        self.timeout = SimpleNamespace(read=60.0)
+        self.calls: list[dict] = []
+
+    async def post(self, url: str, data: dict, headers: dict) -> _FakeResponse:
+        self.calls.append({"url": url, "data": data, "headers": headers})
+        if self.exc is not None:
+            raise self.exc
+        assert self.response is not None
+        self.response.url = url
+        return self.response
+
+
+def _reload_server_with_sparql_history(monkeypatch, tmp_path: Path, enabled: bool):
+    history_path = tmp_path / "sparql-history.jsonl"
+    monkeypatch.delenv("TOGOMCP_QUERY_LOG", raising=False)
+    if enabled:
+        monkeypatch.setenv("TOGOMCP_SPARQL_HISTORY", str(history_path))
+    else:
+        monkeypatch.delenv("TOGOMCP_SPARQL_HISTORY", raising=False)
+    import togo_mcp.server as srv
+    importlib.reload(srv)
+    return srv, history_path
+```
+
+- [ ] **Step 2: Add the disabled-history test**
+
+Append this test class after `TestToolCallLogger`:
+
+```python
+class TestSparqlHistoryLogger:
+    def test_disabled_history_does_not_write_file(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=False)
+        fake_client = _FakeSparqlClient(_FakeResponse("x\n1\n", 200))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        out = asyncio.run(srv.execute_sparql("SELECT * WHERE { ?s ?p ?o } LIMIT 1", database="uniprot"))
+
+        assert out == "x\n1\n"
+        assert not history_path.exists()
+```
+
+- [ ] **Step 3: Add the successful-history test**
+
+Add this method inside `TestSparqlHistoryLogger`:
+
+```python
+    def test_successful_sparql_writes_history_record(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        body = "protein\nP04637\nQ9Y6K9\n"
+        fake_client = _FakeSparqlClient(_FakeResponse(body, 200))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+        query = "SELECT ?protein WHERE { ?protein ?p ?o } LIMIT 2"
+
+        out = asyncio.run(srv.execute_sparql(query, database="uniprot"))
+
+        assert out == body
+        records = _read_jsonl(history_path)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["database"] == "uniprot"
+        assert rec["endpoint_name"] == ""
+        assert rec["endpoint_url"] == srv.SPARQL_ENDPOINT["uniprot"]["url"]
+        assert rec["sparql_query"] == query
+        assert rec["status"] == "ok"
+        assert rec["http_code"] == 200
+        assert rec["n_rows"] == 2
+        assert rec["n_bytes"] == len(body.encode("utf-8"))
+        assert rec["query_sha256"]
+        assert rec["result_sha256"]
+        assert isinstance(rec["elapsed_ms"], (int, float))
+```
+
+- [ ] **Step 4: Add HTTP error and timeout tests**
+
+Add these methods inside `TestSparqlHistoryLogger`:
+
+```python
+    def test_http_error_writes_history_record(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        fake_client = _FakeSparqlClient(_FakeResponse("bad sparql", 400))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        with pytest.raises(ValueError, match="HTTP 400"):
+            asyncio.run(srv.execute_sparql("BROKEN", database="uniprot"))
+
+        rec = _read_jsonl(history_path)[0]
+        assert rec["status"] == "http_4xx"
+        assert rec["http_code"] == 400
+        assert rec["n_bytes"] == len(b"bad sparql")
+        assert rec["sparql_query"] == "BROKEN"
+        assert rec["error_class"] == "ValueError"
+        assert "HTTP 400" in rec["error_message"]
+
+    def test_timeout_writes_history_record(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        fake_client = _FakeSparqlClient(exc=srv.httpx.TimeoutException("slow"))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        with pytest.raises(ValueError, match="timed out"):
+            asyncio.run(srv.execute_sparql("SELECT * WHERE { ?s ?p ?o }", database="uniprot"))
+
+        rec = _read_jsonl(history_path)[0]
+        assert rec["status"] == "timeout"
+        assert rec["database"] == "uniprot"
+        assert rec["endpoint_url"] == srv.SPARQL_ENDPOINT["uniprot"]["url"]
+        assert rec["error_class"] == "ValueError"
+        assert "timed out" in rec["error_message"]
+```
+
+- [ ] **Step 5: Add write-failure safety test**
+
+Add this method inside `TestSparqlHistoryLogger`:
+
+```python
+    def test_history_write_failure_does_not_fail_sparql(self, monkeypatch, tmp_path: Path) -> None:
+        srv, _history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        body = "x\n1\n"
+        fake_client = _FakeSparqlClient(_FakeResponse(body, 200))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        def fail_write(_record: dict) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(srv._sparql_history_logger, "write", fail_write)
+
+        out = asyncio.run(srv.execute_sparql("SELECT * WHERE { ?s ?p ?o } LIMIT 1", database="uniprot"))
+
+        assert out == body
+```
+
+- [ ] **Step 6: Run tests and verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py::TestSparqlHistoryLogger -v
+```
+
+Expected: tests fail with `AttributeError` or missing-file assertions because `_SparqlHistoryLogger` and history writing are not implemented yet.
+
+## Task 2: Implement `_SparqlHistoryLogger`
+
+**Files:**
+- Modify: `togo_mcp/server.py`
+
+- [ ] **Step 1: Add a helper class before `execute_sparql()`**
+
+Insert this class after `raise_for_status_with_body()` and before `execute_sparql()`:
+
+```python
+class _SparqlHistoryLogger:
+    """Append reproducibility-focused SPARQL execution records to JSONL.
+
+    Enabled by setting TOGOMCP_SPARQL_HISTORY to a filesystem path. Logging is
+    best-effort and must never break SPARQL execution.
+    """
+
+    def __init__(self) -> None:
+        log_path = os.getenv("TOGOMCP_SPARQL_HISTORY", "").strip()
+        self._enabled = bool(log_path)
+        self._log: logging.Logger | None = None
+        if not self._enabled:
+            return
+        try:
+            Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+            handler = RotatingFileHandler(
+                log_path, maxBytes=50_000_000, backupCount=10, encoding="utf-8"
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            log = logging.getLogger("togomcp.sparql_history")
+            log.setLevel(logging.INFO)
+            log.propagate = False
+            log.handlers = [handler]
+            self._log = log
+        except Exception as exc:
+            self._enabled = False
+            logger.warning("SPARQL history logging disabled: %s", exc)
+
+    def write(self, record: dict[str, Any]) -> None:
+        if not self._enabled or self._log is None:
+            return
+        try:
+            self._log.info(json.dumps(record, default=str))
+        except Exception as exc:
+            logger.warning("Failed to write SPARQL history record: %s", exc)
+
+
+_sparql_history_logger = _SparqlHistoryLogger()
+```
+
+- [ ] **Step 2: Run the disabled test**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py::TestSparqlHistoryLogger::test_disabled_history_does_not_write_file -v
+```
+
+Expected: still fails because `execute_sparql()` does not call `_sparql_history_logger.write()` yet.
+
+## Task 3: Write SPARQL history records from `execute_sparql()`
+
+**Files:**
+- Modify: `togo_mcp/server.py`
+
+- [ ] **Step 1: Replace the body of `execute_sparql()` with history-aware code**
+
+Keep the function signature and docstring. Replace the implementation body with this code:
+
+```python
+    start = time.perf_counter()
+    status = "error"
+    error_class: str | None = None
+    error_message: str | None = None
+    response: httpx.Response | None = None
+    url: str | None = None
+
+    extra: dict[str, Any] = {
+        "query_sha256": hashlib.sha256(sparql_query.strip().encode("utf-8")).hexdigest(),
+    }
+    _sparql_extra_var.set(extra)
+
+    try:
+        url = resolve_endpoint_url(database, endpoint_name, endpoint_url)
+        extra["endpoint_url"] = url
+
+        response = await _sparql_client.post(
+            url, data={"query": sparql_query}, headers={"Accept": "text/csv"}
+        )
+    except httpx.TimeoutException as exc:
+        status = "timeout"
+        extra["sparql_status"] = status
+        error_class = "ValueError"
+        error_message = (
+            f"SPARQL endpoint at {url} timed out after {_sparql_client.timeout.read}s. "
+            "The query is likely too heavy. Add LIMIT, narrow with specific IRIs or GRAPH "
+            "clauses, or split into smaller queries. Do not retry the same query without "
+            f"changes. ({exc.__class__.__name__})"
+        )
+        raise ValueError(error_message) from exc
+    except httpx.HTTPError as exc:
+        status = "network_error"
+        extra["sparql_status"] = status
+        error_class = "ValueError"
+        error_message = (
+            f"SPARQL endpoint at {url} could not be reached: "
+            f"{exc.__class__.__name__}: {exc}"
+        )
+        raise ValueError(error_message) from exc
+    except BaseException as exc:
+        status = "error"
+        extra["sparql_status"] = status
+        error_class = exc.__class__.__name__
+        error_message = str(exc)
+        raise
+    else:
+        extra["http_code"] = response.status_code
+        extra["n_bytes"] = len(response.content)
+        if response.is_success:
+            status = "ok"
+            extra["sparql_status"] = status
+            extra["n_rows"] = max(response.text.count("\n") - 1, 0)
+            extra["result_sha256"] = hashlib.sha256(response.content).hexdigest()
+        elif 400 <= response.status_code < 500:
+            status = "http_4xx"
+            extra["sparql_status"] = status
+        else:
+            status = "http_5xx"
+            extra["sparql_status"] = status
+
+        try:
+            raise_for_status_with_body(
+                response,
+                context="SPARQL endpoint",
+                client_error_hint=(
+                    "The endpoint diagnostic above usually names the exact line/column. "
+                    "Common causes: syntax error (missing brace/comma), undefined namespace "
+                    "prefix, unsupported function. Fix the query — do not retry the same text."
+                ),
+                server_error_hint=(
+                    "This may be transient or indicate the query is too heavy. Consider "
+                    "adding LIMIT, stronger filters (specific IRIs, GRAPH clauses), or "
+                    "splitting the query."
+                ),
+            )
+        except BaseException as exc:
+            error_class = exc.__class__.__name__
+            error_message = str(exc)
+            raise
+        return response.text
+    finally:
+        record: dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "database": database,
+            "endpoint_name": endpoint_name,
+            "endpoint_url": url,
+            "sparql_query": sparql_query,
+            "query_sha256": extra["query_sha256"],
+            "status": status,
+            "elapsed_ms": round((time.perf_counter() - start) * 1000, 2),
+        }
+        for key in ("http_code", "n_rows", "n_bytes", "result_sha256"):
+            if key in extra:
+                record[key] = extra[key]
+        if error_class is not None:
+            record["error_class"] = error_class
+        if error_message is not None:
+            record["error_message"] = error_message[:500]
+        try:
+            _sparql_history_logger.write(record)
+        except Exception as exc:
+            logger.warning("Failed to write SPARQL history record: %s", exc)
+```
+
+- [ ] **Step 2: Run focused SPARQL history tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py::TestSparqlHistoryLogger -v
+```
+
+Expected: all `TestSparqlHistoryLogger` tests pass.
+
+- [ ] **Step 3: Run all server tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py -v
+```
+
+Expected: all tests in `tests/test_server.py` pass.
+
+- [ ] **Step 4: Commit implementation and tests**
+
+Run:
+
+```bash
+git add togo_mcp/server.py tests/test_server.py
+git commit -m "feat: add SPARQL history logging"
+```
+
+Expected: commit succeeds.
+
+## Task 4: Document and configure SPARQL history logging
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.env.example`
+- Modify: `compose.yaml`
+
+- [ ] **Step 1: Update `README.md` Tool-Call Logging section**
+
+In `README.md`, after the paragraph that introduces `TOGOMCP_QUERY_LOG`, add:
+
+```markdown
+### SPARQL History Logging (Optional)
+
+For reproducibility, TogoMCP can also record a SPARQL-only execution history.
+Set `TOGOMCP_SPARQL_HISTORY` to a writable JSONL path. Each `run_sparql` call
+appends the exact SPARQL text, original database/endpoint arguments, resolved
+endpoint URL, status, HTTP code, elapsed time, row/byte counts, query SHA-256,
+and result SHA-256. Full result bodies are not stored.
+
+This is separate from `TOGOMCP_QUERY_LOG`: use `TOGOMCP_QUERY_LOG` for complete
+MCP tool-call auditing, and `TOGOMCP_SPARQL_HISTORY` when you mainly need to
+reproduce or debug SPARQL runs.
+```
+
+In the Docker subsection of Tool-Call Logging, add:
+
+```markdown
+To enable SPARQL history in Docker as well:
+
+```bash
+echo 'TOGOMCP_SPARQL_HISTORY=/var/log/togomcp/sparql-history.jsonl' >> .env
+docker compose up -d togomcp-main
+tail -f logs/sparql-history.jsonl
+```
+```
+
+In the Claude Desktop local stdio example, extend the env block to include:
+
+```json
+"TOGOMCP_SPARQL_HISTORY": "/Users/you/togomcp-logs/sparql-history.jsonl"
+```
+
+- [ ] **Step 2: Update `.env.example`**
+
+After the existing `TOGOMCP_QUERY_LOG` examples, add:
+
+```dotenv
+# Optional: enable SPARQL-only history logging for reproducibility.
+# This stores exact query text and compact execution metadata, not full results.
+# TOGOMCP_SPARQL_HISTORY=/var/log/togomcp/sparql-history.jsonl
+# TOGOMCP_SPARQL_HISTORY_TEST=/var/log/togomcp/sparql-history-test.jsonl
+```
+
+- [ ] **Step 3: Update `compose.yaml`**
+
+In service `togomcp-main.environment`, add:
+
+```yaml
+      TOGOMCP_SPARQL_HISTORY: ${TOGOMCP_SPARQL_HISTORY:-}
+```
+
+In service `togomcp-test.environment`, add:
+
+```yaml
+      TOGOMCP_SPARQL_HISTORY: ${TOGOMCP_SPARQL_HISTORY_TEST:-}
+```
+
+- [ ] **Step 4: Run documentation/config sanity checks**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py -v
+```
+
+Expected: all tests in `tests/test_server.py` pass.
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 5: Commit documentation/config changes**
+
+Run:
+
+```bash
+git add README.md .env.example compose.yaml
+git commit -m "docs: document SPARQL history logging"
+```
+
+Expected: commit succeeds.
+
+## Task 5: Final verification
+
+**Files:**
+- Inspect: `togo_mcp/server.py`
+- Inspect: `tests/test_server.py`
+- Inspect: `README.md`
+- Inspect: `.env.example`
+- Inspect: `compose.yaml`
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py -v
+```
+
+Expected: all tests in `tests/test_server.py` pass.
+
+- [ ] **Step 2: Run broader test suite if practical**
+
+Run:
+
+```bash
+uv run pytest tests/test_server.py tests/test_ncbi_tools.py -v
+```
+
+Expected: all selected tests pass. Do not block on `tests/test_api_tools.py` unless explicitly requested because `CLAUDE.md` notes pre-existing FunctionTool-callability failures there.
+
+- [ ] **Step 3: Verify final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~2..HEAD
+git status --short
+```
+
+Expected: only the intended files changed; working tree is clean after commits.
+
+- [ ] **Step 4: Report completion**
+
+Summarize:
+
+- New environment variable: `TOGOMCP_SPARQL_HISTORY`
+- What the JSONL records include
+- Verification commands run and results
+- Any tests intentionally not run

--- a/docs/superpowers/specs/2026-05-19-sparql-history-design.md
+++ b/docs/superpowers/specs/2026-05-19-sparql-history-design.md
@@ -1,0 +1,116 @@
+# SPARQL History Logging Design
+
+## Purpose
+
+Add a SPARQL-specific execution history log to improve reproducibility and debugging. TogoMCP already supports `TOGOMCP_QUERY_LOG`, which records general MCP tool calls. This feature adds a narrower history stream for `run_sparql` executions so users can recover the exact query, resolved endpoint, outcome, and compact result metadata without digging through all tool calls.
+
+## Goals
+
+- Preserve the exact SPARQL text used for each `run_sparql` execution.
+- Record enough endpoint information to reproduce the request later.
+- Capture success and failure metadata useful for debugging.
+- Keep normal `run_sparql` behavior and return values unchanged.
+- Make the feature opt-in with zero overhead when disabled.
+- Avoid storing full query results by default to prevent large logs and reduce sensitive-data risk.
+
+## Non-goals
+
+- Do not add MCP tools for browsing, searching, or rerunning history in the first implementation.
+- Do not store full SPARQL result bodies.
+- Do not replace `TOGOMCP_QUERY_LOG`; the new history log complements it.
+
+## User-facing behavior
+
+A new environment variable enables the history file:
+
+```bash
+TOGOMCP_SPARQL_HISTORY=/path/to/sparql-history.jsonl
+```
+
+When unset or empty, no SPARQL history file is created. When set, every `run_sparql` execution appends one JSON object per line. The JSONL file is intended for command-line inspection, post-processing, benchmark analysis, and future MCP history tools.
+
+## History record schema
+
+Each line should contain a JSON object with these fields where available:
+
+- `ts`: UTC ISO-8601 timestamp.
+- `database`: original `database` argument after alias resolution.
+- `endpoint_name`: original `endpoint_name` argument.
+- `endpoint_url`: resolved endpoint URL used for the HTTP request.
+- `sparql_query`: exact SPARQL query string submitted.
+- `query_sha256`: SHA-256 hash of the stripped query text.
+- `status`: `ok`, `timeout`, `network_error`, `http_4xx`, `http_5xx`, or `error`.
+- `elapsed_ms`: elapsed time for endpoint resolution and HTTP execution.
+- `http_code`: HTTP status code when an HTTP response exists.
+- `n_rows`: approximate number of result rows for successful CSV responses.
+- `n_bytes`: response byte count when an HTTP response exists.
+- `result_sha256`: SHA-256 hash of the response body for successful responses.
+- `error_class`: exception class name for failures.
+- `error_message`: truncated diagnostic message for failures.
+
+The schema should be additive: future versions may append fields, but should not remove or rename these fields casually.
+
+## Architecture
+
+Implement the history writer in `togo_mcp/server.py`, near the existing SPARQL execution and tool-call logging code.
+
+Recommended structure:
+
+1. Add a small helper class or function that lazily initializes a `RotatingFileHandler` from `TOGOMCP_SPARQL_HISTORY`.
+2. Update `execute_sparql()` to collect SPARQL-specific metadata around endpoint resolution and the HTTP call.
+3. In a `finally` block, append a JSONL record only when history logging is enabled.
+4. Keep logging failure-safe: inability to write the history file must not break the user’s SPARQL call.
+
+The existing `_ToolCallLogger` should remain unchanged except for any shared helper extraction that clearly reduces duplication. The new history path should be separate from `TOGOMCP_QUERY_LOG` so operators can enable either log independently.
+
+## Data flow
+
+```mermaid
+flowchart TD
+    A[run_sparql tool call] --> B[resolve database / endpoint]
+    B --> C[execute SPARQL HTTP POST]
+    C --> D[return CSV or raise diagnostic]
+    C --> E{TOGOMCP_SPARQL_HISTORY set?}
+    E -->|no| F[no history write]
+    E -->|yes| G[append JSONL history record]
+```
+
+## Error handling
+
+- Endpoint resolution errors should be recorded when possible with `status: "error"` and no `endpoint_url` if resolution failed.
+- HTTP timeout should record `status: "timeout"`.
+- Network errors should record `status: "network_error"`.
+- 4xx and 5xx responses should record `http_4xx` or `http_5xx` plus response byte count and truncated error diagnostic.
+- History logging errors should be swallowed after best-effort internal logger warning, because observability must not break query execution.
+
+## Documentation updates
+
+Update `README.md` near the existing Tool-Call Logging section:
+
+- Explain the difference between `TOGOMCP_QUERY_LOG` and `TOGOMCP_SPARQL_HISTORY`.
+- Show local stdio and Docker examples.
+- State that full result bodies are not stored; only hashes and compact metadata are recorded.
+
+Update `.env.example` if it already documents logging-related environment variables.
+
+## Testing strategy
+
+Add focused tests in `tests/test_server.py`:
+
+1. Disabled history logging does not write a file.
+2. Successful SPARQL execution writes one JSONL record with query text, resolved endpoint URL, status, row/byte counts, and result hash.
+3. HTTP error writes one JSONL record with failure status and diagnostic metadata.
+4. Timeout or network error paths record failure status without masking the original exception.
+5. History logging write failures do not fail the SPARQL call.
+
+Use `respx` or monkeypatching around `_sparql_client.post` to avoid real network calls.
+
+## Future extensions
+
+This design intentionally leaves room for future MCP tools such as:
+
+- `list_sparql_history`
+- `get_sparql_history_entry`
+- `rerun_sparql_history_entry`
+
+Those tools should be added only after the JSONL format is stable and the project has clear requirements for privacy, pagination, and safe reruns.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -204,6 +204,46 @@ def _make_logger(monkeypatch, tmp_path: Path, enabled: bool):
     return srv._ToolCallLogger(), srv, log_path
 
 
+class _FakeResponse:
+    def __init__(self, text: str, status_code: int, url: str = "https://fake.example/sparql") -> None:
+        self.text = text
+        self.status_code = status_code
+        self.url = url
+        self.content = text.encode("utf-8")
+
+    @property
+    def is_success(self) -> bool:
+        return 200 <= self.status_code < 300
+
+
+class _FakeSparqlClient:
+    def __init__(self, response: _FakeResponse | None = None, exc: Exception | None = None) -> None:
+        self.response = response
+        self.exc = exc
+        self.timeout = SimpleNamespace(read=60.0)
+        self.calls: list[dict] = []
+
+    async def post(self, url: str, data: dict, headers: dict) -> _FakeResponse:
+        self.calls.append({"url": url, "data": data, "headers": headers})
+        if self.exc is not None:
+            raise self.exc
+        assert self.response is not None
+        self.response.url = url
+        return self.response
+
+
+def _reload_server_with_sparql_history(monkeypatch, tmp_path: Path, enabled: bool):
+    history_path = tmp_path / "sparql-history.jsonl"
+    monkeypatch.delenv("TOGOMCP_QUERY_LOG", raising=False)
+    if enabled:
+        monkeypatch.setenv("TOGOMCP_SPARQL_HISTORY", str(history_path))
+    else:
+        monkeypatch.delenv("TOGOMCP_SPARQL_HISTORY", raising=False)
+    import togo_mcp.server as srv
+    importlib.reload(srv)
+    return srv, history_path
+
+
 class TestToolCallLogger:
     def test_disabled_short_circuits(self, monkeypatch, tmp_path: Path) -> None:
         mw, _srv, log_path = _make_logger(monkeypatch, tmp_path, enabled=False)
@@ -272,3 +312,85 @@ class TestToolCallLogger:
         assert rec["extra"]["endpoint_url"] == "https://x/sparql"
         assert rec["extra"]["sparql_status"] == "ok"
         assert rec["extra"]["n_rows"] == 3
+
+class TestSparqlHistoryLogger:
+    def test_disabled_history_does_not_write_file(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=False)
+        fake_client = _FakeSparqlClient(_FakeResponse("x\n1\n", 200))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        out = asyncio.run(srv.execute_sparql("SELECT * WHERE { ?s ?p ?o } LIMIT 1", database="uniprot"))
+
+        assert out == "x\n1\n"
+        assert not history_path.exists()
+
+    def test_successful_sparql_writes_history_record(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        body = "protein\nP04637\nQ9Y6K9\n"
+        fake_client = _FakeSparqlClient(_FakeResponse(body, 200))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+        query = "SELECT ?protein WHERE { ?protein ?p ?o } LIMIT 2"
+
+        out = asyncio.run(srv.execute_sparql(query, database="uniprot"))
+
+        assert out == body
+        records = _read_jsonl(history_path)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["database"] == "uniprot"
+        assert rec["endpoint_name"] == ""
+        assert rec["endpoint_url"] == srv.SPARQL_ENDPOINT["uniprot"]["url"]
+        assert rec["sparql_query"] == query
+        assert rec["status"] == "ok"
+        assert rec["http_code"] == 200
+        assert rec["n_rows"] == 2
+        assert rec["n_bytes"] == len(body.encode("utf-8"))
+        assert rec["query_sha256"]
+        assert rec["result_sha256"]
+        assert isinstance(rec["elapsed_ms"], (int, float))
+
+    def test_http_error_writes_history_record(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        fake_client = _FakeSparqlClient(_FakeResponse("bad sparql", 400))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        with pytest.raises(ValueError, match="HTTP 400"):
+            asyncio.run(srv.execute_sparql("BROKEN", database="uniprot"))
+
+        rec = _read_jsonl(history_path)[0]
+        assert rec["status"] == "http_4xx"
+        assert rec["http_code"] == 400
+        assert rec["n_bytes"] == len(b"bad sparql")
+        assert rec["sparql_query"] == "BROKEN"
+        assert rec["error_class"] == "ValueError"
+        assert "HTTP 400" in rec["error_message"]
+
+    def test_timeout_writes_history_record(self, monkeypatch, tmp_path: Path) -> None:
+        srv, history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        fake_client = _FakeSparqlClient(exc=srv.httpx.TimeoutException("slow"))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        with pytest.raises(ValueError, match="timed out"):
+            asyncio.run(srv.execute_sparql("SELECT * WHERE { ?s ?p ?o }", database="uniprot"))
+
+        rec = _read_jsonl(history_path)[0]
+        assert rec["status"] == "timeout"
+        assert rec["database"] == "uniprot"
+        assert rec["endpoint_url"] == srv.SPARQL_ENDPOINT["uniprot"]["url"]
+        assert rec["error_class"] == "ValueError"
+        assert "timed out" in rec["error_message"]
+
+    def test_history_write_failure_does_not_fail_sparql(self, monkeypatch, tmp_path: Path) -> None:
+        srv, _history_path = _reload_server_with_sparql_history(monkeypatch, tmp_path, enabled=True)
+        body = "x\n1\n"
+        fake_client = _FakeSparqlClient(_FakeResponse(body, 200))
+        monkeypatch.setattr(srv, "_sparql_client", fake_client)
+
+        def fail_write(_record: dict) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(srv._sparql_history_logger, "write", fail_write)
+
+        out = asyncio.run(srv.execute_sparql("SELECT * WHERE { ?s ?p ?o } LIMIT 1", database="uniprot"))
+
+        assert out == body

--- a/togo_mcp/server.py
+++ b/togo_mcp/server.py
@@ -189,6 +189,46 @@ def raise_for_status_with_body(
     )
 
 
+class _SparqlHistoryLogger:
+    """Append reproducibility-focused SPARQL execution records to JSONL.
+
+    Enabled by setting TOGOMCP_SPARQL_HISTORY to a filesystem path. Logging is
+    best-effort and must never break SPARQL execution.
+    """
+
+    def __init__(self) -> None:
+        log_path = os.getenv("TOGOMCP_SPARQL_HISTORY", "").strip()
+        self._enabled = bool(log_path)
+        self._log: logging.Logger | None = None
+        if not self._enabled:
+            return
+        try:
+            Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+            handler = RotatingFileHandler(
+                log_path, maxBytes=50_000_000, backupCount=10, encoding="utf-8"
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            log = logging.getLogger("togomcp.sparql_history")
+            log.setLevel(logging.INFO)
+            log.propagate = False
+            log.handlers = [handler]
+            self._log = log
+        except Exception as exc:
+            self._enabled = False
+            logger.warning("SPARQL history logging disabled: %s", exc)
+
+    def write(self, record: dict[str, Any]) -> None:
+        if not self._enabled or self._log is None:
+            return
+        try:
+            self._log.info(json.dumps(record, default=str))
+        except Exception as exc:
+            logger.warning("Failed to write SPARQL history record: %s", exc)
+
+
+_sparql_history_logger = _SparqlHistoryLogger()
+
+
 # Making this a @mcp.tool() becomes an error, so we keep it as a function.
 async def execute_sparql(
     sparql_query: str,
@@ -211,58 +251,108 @@ async def execute_sparql(
         Priority: endpoint_url > endpoint_name > database
         For cross-database queries on shared endpoints, use endpoint_name or endpoint_url.
     """
-    url = resolve_endpoint_url(database, endpoint_name, endpoint_url)
+    start = time.perf_counter()
+    status = "error"
+    error_class: str | None = None
+    error_message: str | None = None
+    response: httpx.Response | None = None
+    url: str | None = None
 
     extra: dict[str, Any] = {
-        "endpoint_url": url,
         "query_sha256": hashlib.sha256(sparql_query.strip().encode("utf-8")).hexdigest(),
     }
     _sparql_extra_var.set(extra)
 
     try:
+        url = resolve_endpoint_url(database, endpoint_name, endpoint_url)
+        extra["endpoint_url"] = url
+
         response = await _sparql_client.post(
             url, data={"query": sparql_query}, headers={"Accept": "text/csv"}
         )
     except httpx.TimeoutException as exc:
-        extra["sparql_status"] = "timeout"
-        raise ValueError(
+        status = "timeout"
+        extra["sparql_status"] = status
+        error_class = "ValueError"
+        error_message = (
             f"SPARQL endpoint at {url} timed out after {_sparql_client.timeout.read}s. "
             "The query is likely too heavy. Add LIMIT, narrow with specific IRIs or GRAPH "
             "clauses, or split into smaller queries. Do not retry the same query without "
             f"changes. ({exc.__class__.__name__})"
-        ) from exc
+        )
+        raise ValueError(error_message) from exc
     except httpx.HTTPError as exc:
-        extra["sparql_status"] = "network_error"
-        raise ValueError(
+        status = "network_error"
+        extra["sparql_status"] = status
+        error_class = "ValueError"
+        error_message = (
             f"SPARQL endpoint at {url} could not be reached: "
             f"{exc.__class__.__name__}: {exc}"
-        ) from exc
-
-    extra["http_code"] = response.status_code
-    extra["n_bytes"] = len(response.content)
-    if response.is_success:
-        extra["sparql_status"] = "ok"
-        extra["n_rows"] = max(response.text.count("\n") - 1, 0)
-    elif 400 <= response.status_code < 500:
-        extra["sparql_status"] = "http_4xx"
+        )
+        raise ValueError(error_message) from exc
+    except BaseException as exc:
+        status = "error"
+        extra["sparql_status"] = status
+        error_class = exc.__class__.__name__
+        error_message = str(exc)
+        raise
     else:
-        extra["sparql_status"] = "http_5xx"
+        extra["http_code"] = response.status_code
+        extra["n_bytes"] = len(response.content)
+        if response.is_success:
+            status = "ok"
+            extra["sparql_status"] = status
+            extra["n_rows"] = max(response.text.count("\n") - 1, 0)
+            extra["result_sha256"] = hashlib.sha256(response.content).hexdigest()
+        elif 400 <= response.status_code < 500:
+            status = "http_4xx"
+            extra["sparql_status"] = status
+        else:
+            status = "http_5xx"
+            extra["sparql_status"] = status
 
-    raise_for_status_with_body(
-        response,
-        context="SPARQL endpoint",
-        client_error_hint=(
-            "The endpoint diagnostic above usually names the exact line/column. "
-            "Common causes: syntax error (missing brace/comma), undefined namespace "
-            "prefix, unsupported function. Fix the query — do not retry the same text."
-        ),
-        server_error_hint=(
-            "This may be transient or indicate the query is too heavy. Consider "
-            "adding LIMIT, stronger filters (specific IRIs, GRAPH clauses), or "
-            "splitting the query."
-        ),
-    )
-    return response.text
+        try:
+            raise_for_status_with_body(
+                response,
+                context="SPARQL endpoint",
+                client_error_hint=(
+                    "The endpoint diagnostic above usually names the exact line/column. "
+                    "Common causes: syntax error (missing brace/comma), undefined namespace "
+                    "prefix, unsupported function. Fix the query — do not retry the same text."
+                ),
+                server_error_hint=(
+                    "This may be transient or indicate the query is too heavy. Consider "
+                    "adding LIMIT, stronger filters (specific IRIs, GRAPH clauses), or "
+                    "splitting the query."
+                ),
+            )
+        except BaseException as exc:
+            error_class = exc.__class__.__name__
+            error_message = str(exc)
+            raise
+        return response.text
+    finally:
+        record: dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "database": database,
+            "endpoint_name": endpoint_name,
+            "endpoint_url": url,
+            "sparql_query": sparql_query,
+            "query_sha256": extra["query_sha256"],
+            "status": status,
+            "elapsed_ms": round((time.perf_counter() - start) * 1000, 2),
+        }
+        for key in ("http_code", "n_rows", "n_bytes", "result_sha256"):
+            if key in extra:
+                record[key] = extra[key]
+        if error_class is not None:
+            record["error_class"] = error_class
+        if error_message is not None:
+            record["error_message"] = error_message[:500]
+        try:
+            _sparql_history_logger.write(record)
+        except Exception as exc:
+            logger.warning("Failed to write SPARQL history record: %s", exc)
 
 
 # The Primary MCP server


### PR DESCRIPTION
## Summary
- Add opt-in `TOGOMCP_SPARQL_HISTORY` JSONL logging for `run_sparql` reproducibility.
- Record exact SPARQL text, resolved endpoint, status, timing, row/byte counts, query/result hashes, and failure diagnostics without storing full result bodies.
- Document Docker/local configuration and add compose/.env pass-through examples.

## Test Plan
- `uv run pytest tests/test_server.py tests/test_ncbi_tools.py -v` → 32 passed
- Final subagent review approved the implementation and docs/config changes.

## Notes
- `TOGOMCP_QUERY_LOG` remains the general MCP tool-call audit log.
- `TOGOMCP_SPARQL_HISTORY` is SPARQL-specific and intended for debugging/reproducibility.
